### PR TITLE
Support NaN/inf JSON extensions

### DIFF
--- a/src/correction.cc
+++ b/src/correction.cc
@@ -418,7 +418,7 @@ std::unique_ptr<CorrectionSet> CorrectionSet::from_file(const std::string& fn) {
   FILE* fp = fopen(fn.c_str(), "rb");
   char readBuffer[65536];
   rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
-  rapidjson::ParseResult ok = json.ParseStream(is);
+  rapidjson::ParseResult ok = json.ParseStream<rapidjson::kParseNanAndInfFlag>(is);
   if (!ok) {
     throw std::runtime_error(
         std::string("JSON parse error: ") + rapidjson::GetParseError_En(ok.Code())
@@ -431,7 +431,7 @@ std::unique_ptr<CorrectionSet> CorrectionSet::from_file(const std::string& fn) {
 
 std::unique_ptr<CorrectionSet> CorrectionSet::from_string(const char * data) {
   rapidjson::Document json;
-  rapidjson::ParseResult ok = json.Parse(data);
+  rapidjson::ParseResult ok = json.Parse<rapidjson::kParseNanAndInfFlag>(data);
   if (!ok) {
     throw std::runtime_error(
         std::string("JSON parse error: ") + rapidjson::GetParseError_En(ok.Code())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -67,7 +67,7 @@ def test_evaluator():
                 {
                     "nodetype": "binning",
                     "input": "pt",
-                    "edges": [0, 20, 40],
+                    "edges": [0, 20, 40, float("inf")],
                     "flow": "error",
                     "content": [
                         schema.Category.parse_obj(
@@ -99,6 +99,7 @@ def test_evaluator():
                                 ],
                             }
                         ),
+                        1.0,
                     ],
                 }
             ),
@@ -128,6 +129,12 @@ def test_evaluator():
     assert sf.evaluate(12.0, "blah") == 1.1
     # Do we need pytest.approx? Maybe not
     assert sf.evaluate(31.0, "blah3") == 0.25 * 31.0 + math.exp(3.1)
+
+    with pytest.raises(RuntimeError):
+        # underflow
+        sf.evaluate(-1.0, "blah")
+
+    assert sf.evaluate(1000.0, "blah") == 1.0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Per rapidjson docs: 
> Allow parsing NaN, Inf, Infinity, -Inf and -Infinity as double values (relaxed JSON syntax).