### PR TITLE
Add support for gzipped files from the C++ reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ FetchContent_MakeAvailable(pybind11)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)
+find_package(ZLIB)
 
 include(CheckCXXCompilerFlag)
 
@@ -45,6 +46,7 @@ target_include_directories(correctionlib
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cpp-peglib>
   )
 target_compile_features(correctionlib PUBLIC cxx_std_17)
+target_link_libraries(correctionlib ZLIB::ZLIB)
 if(Threads_FOUND AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(correctionlib Threads::Threads)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 endif
 OSXFLAG=$(shell uname|grep -q Darwin && echo "-undefined dynamic_lookup")
 CFLAGS=--std=c++17 -O3 -Wall -fPIC -Irapidjson/include -Ipybind11/include -Icpp-peglib $(PYINC) -Iinclude
-LDFLAGS=-pthread
+LDFLAGS=-pthread -lz
 PREFIX ?= /usr
 STRVER=$(shell git describe --tags)
 MAJOR=$(shell git describe --tags|sed -n "s/v\([0-9]\+\)\..*/\1/p")

--- a/src/gzfilereadstream.h
+++ b/src/gzfilereadstream.h
@@ -1,0 +1,101 @@
+// Copied from https://github.com/Tencent/rapidjson/pull/1745, to be taken from RapidJSON once merged
+
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef RAPIDJSON_GZFILEREADSTREAM_H_
+#define RAPIDJSON_GZFILEREADSTREAM_H_
+
+#include "rapidjson/stream.h"
+#include <zlib.h>
+
+#ifdef __clang__
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(padded)
+RAPIDJSON_DIAG_OFF(unreachable-code)
+RAPIDJSON_DIAG_OFF(missing-noreturn)
+#endif
+
+RAPIDJSON_NAMESPACE_BEGIN
+
+//! gzFile byte stream for input using gzread() from zlib.h.
+/*!
+    \note implements Stream concept
+*/
+class GzFileReadStream {
+public:
+    typedef char Ch;    //!< Character type (byte).
+
+    //! Constructor.
+    /*!
+        \param fp gzFile_s pointer opened for read.
+        \param buffer user-supplied buffer.
+        \param bufferSize size of buffer in bytes. Must >=4 bytes.
+    */
+    GzFileReadStream(gzFile_s* fp, char* buffer, size_t bufferSize) : fp_(fp), buffer_(buffer), bufferSize_(bufferSize), bufferLast_(0), current_(buffer_), readCount_(0), count_(0), eof_(false) {
+        RAPIDJSON_ASSERT(fp_ != 0);
+        RAPIDJSON_ASSERT(bufferSize >= 4);
+        Read();
+    }
+
+    Ch Peek() const { return *current_; }
+    Ch Take() { Ch c = *current_; Read(); return c; }
+    size_t Tell() const { return count_ + static_cast<size_t>(current_ - buffer_); }
+
+    // Not implemented
+    void Put(Ch) { RAPIDJSON_ASSERT(false); }
+    void Flush() { RAPIDJSON_ASSERT(false); }
+    Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+    size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
+
+    // For encoding detection only.
+    const Ch* Peek4() const {
+        return (current_ + 4 <= bufferLast_) ? current_ : 0;
+    }
+
+private:
+    void Read() {
+        if (current_ < bufferLast_)
+            ++current_;
+        else if (!eof_) {
+            count_ += readCount_;
+            readCount_ = gzread(fp_, buffer_, bufferSize_);
+            bufferLast_ = buffer_ + readCount_ - 1;
+            current_ = buffer_;
+
+            if (readCount_ < bufferSize_) {
+                buffer_[readCount_] = '\0';
+                ++bufferLast_;
+                eof_ = true;
+            }
+        }
+    }
+
+    gzFile_s* fp_;
+    Ch *buffer_;
+    size_t bufferSize_;
+    Ch *bufferLast_;
+    Ch *current_;
+    size_t readCount_;
+    size_t count_;  //!< Number of characters read
+    bool eof_;
+};
+
+RAPIDJSON_NAMESPACE_END
+
+#ifdef __clang__
+RAPIDJSON_DIAG_POP
+#endif
+
+#endif // RAPIDJSON_GZFILESTREAM_H_


### PR DESCRIPTION
Closes https://github.com/cms-nanoAOD/correctionlib/issues/27

Using a magic number check and the gzfilereadstream from https://github.com/Tencent/rapidjson/pull/1745 (I'm not sure about the copyright/license issues of including the header from the PR, though).

Testing done: builds with make and cmake (for the wheels etc. the CI tests will tell), and this works:
```C++
% root -l
root [0] gSystem->Load("lib/libcorrectionlib.so")
(int) 0
root [1] #include "include/correction.h"
root [2] auto cset = correction::CorrectionSet::from_file("/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/TAU/2018_UL/tau.json");
root [3] auto cset2 = correction::CorrectionSet::from_file("/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2018_UL/muon_Z.json.gz");
root [4] cset->validate()
(bool) true
root [5] cset2->validate()
(bool) true
```