### PR TITLE
(CLI): include compound corrections in merge

### DIFF
--- a/src/correctionlib/cli.py
+++ b/src/correctionlib/cli.py
@@ -89,8 +89,11 @@ def merge(console: Console, args: argparse.Namespace) -> int:
                 )
                 return 1
             cset.corrections.append(corr2)
-        for corr2 in (cset2.compound_corrections if cset2.compound_corrections!=None else []):
-            if cset.compound_corrections==None: cset.compound_corrections = []
+        for corr2 in (
+            cset2.compound_corrections if cset2.compound_corrections != None else []
+        ):
+            if cset.compound_corrections == None:
+                cset.compound_corrections = []
             if any(corr.name == corr2.name for corr in cset.compound_corrections):
                 console.print(
                     f"[red]Compound correction '{corr2.name}' from {file} is a duplicate"

--- a/src/correctionlib/cli.py
+++ b/src/correctionlib/cli.py
@@ -89,6 +89,14 @@ def merge(console: Console, args: argparse.Namespace) -> int:
                 )
                 return 1
             cset.corrections.append(corr2)
+        for corr2 in (cset2.compound_corrections if cset2.compound_corrections!=None else []):
+            if cset.compound_corrections==None: cset.compound_corrections = []
+            if any(corr.name == corr2.name for corr in cset.compound_corrections):
+                console.print(
+                    f"[red]Compound correction '{corr2.name}' from {file} is a duplicate"
+                )
+                return 1
+            cset.compound_corrections.append(corr2)
     cset.description = "Merged from " + " ".join(args.files)
     if args.format == "compact":
         sys.stdout.write(cset.json())

--- a/src/correctionlib/cli.py
+++ b/src/correctionlib/cli.py
@@ -90,10 +90,8 @@ def merge(console: Console, args: argparse.Namespace) -> int:
                 )
                 return 1
             cset.corrections.append(corr2)
-        for corr2 in (
-            cset2.compound_corrections if cset2.compound_corrections != None else []
-        ):
-            if cset.compound_corrections == None:
+        for corr2 in cset2.compound_corrections if cset2.compound_corrections else []:
+            if cset.compound_corrections is None:
                 cset.compound_corrections = []
             if any(corr.name == corr2.name for corr in cset.compound_corrections):
                 console.print(


### PR DESCRIPTION
Only the "corrections" property of CorrectionSets was merged before, resulting in inconsistent merged JSON files, when CompoundCorrection is used in source JSONs.