### PR TITLE
Convert from uproot: fix bug, specify axis names and flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
     - uses: pre-commit/action@v2.0.3
       with:
         extra_args: --hook-stage manual --all-files
@@ -41,7 +41,7 @@ jobs:
       with:
         submodules: recursive
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/src/correctionlib/convert.py
+++ b/src/correctionlib/convert.py
@@ -59,7 +59,6 @@ def from_histogram(hist: "PlottableHistogram") -> Correction:
     def edges(axis: "PlottableAxis") -> List[float]:
         out = []
         for i, b in enumerate(axis):
-            assert isinstance(b, tuple)
             out.append(b[0])
             if i == len(axis) - 1:
                 out.append(b[1])

--- a/src/correctionlib/convert.py
+++ b/src/correctionlib/convert.py
@@ -8,23 +8,35 @@ from typing import (
     Any,
     Iterable,
     List,
-    Literal,
     Optional,
     Sequence,
+    Tuple,
     Union,
+    cast,
 )
 
 from .schemav2 import Binning, Category, Content, Correction, MultiBinning, Variable
 
 if TYPE_CHECKING:
     from numpy import ndarray
+    from typing_extensions import Literal
     from uhi.typing.plottable import PlottableAxis, PlottableHistogram
+else:
+    # py3.8+: no longer necessary
+    try:
+        from typing import Literal
+    except ImportError:
+        from typing_extensions import Literal
+
+
+def blah(x: Literal["a", "b"]) -> str:
+    return x + "c"
 
 
 def from_uproot_THx(
     path: str,
     axis_names: Optional[List[str]] = None,
-    flow: Optional[Union[Content, Literal["clamp", "error"]]] = "error",
+    flow: Literal["clamp", "error"] = "error",
 ) -> Correction:
     """Convert a ROOT histogram
 
@@ -83,6 +95,7 @@ def from_histogram(
                 raise ValueError(
                     "cannot auto-convert string or integer category axes (yet)"
                 )
+            b = cast(Tuple[float, float], b)
             out.append(b[0])
             if i == len(axis) - 1:
                 out.append(b[1])

--- a/src/correctionlib/schemav2.py
+++ b/src/correctionlib/schemav2.py
@@ -9,6 +9,7 @@ from rich.tree import Tree
 
 import correctionlib.highlevel
 
+# py3.8+: no longer necessary
 try:
     from typing import Literal  # type: ignore
 except ImportError:


### PR DESCRIPTION
`convert.from_uproot_THx` did not work with uproot 4.2.0 because of the `TAxis` behaviour: the elements obtained when iterating on an axis are not tuples but numpy arrays. Simply removing the `isinstance` assertion makes it work fine.

I've also added the possibility to specify the axis names and flow in `from_uproot_THx` and `from_histogram`, to make those slightly more useful,