### PR TITLE
Correcting axes types for histogram conversion

### DIFF
--- a/src/correctionlib/convert.py
+++ b/src/correctionlib/convert.py
@@ -71,9 +71,9 @@ def from_histogram(
         if len(axis) == 0:
             raise ValueError(f"Zero-length axis {axis}, what to do?")
         elif isinstance(axis[0], str):
-            axtype = "str"
+            axtype = "string"
         elif isinstance(axis[0], int):
-            axtype = "integer"
+            axtype = "int"
         axname = getattr(
             axis, "name", f"axis{pos}" if axis_names is None else axis_names[pos]
         )


### PR DESCRIPTION
The definition of the axes types for histogram conversion were not the expected ones ("string", "int", "real"). 

For example, with the proposed changes the  histogram below got converted correctly. 
```
(StrCategory([...], growth=True, name='Sample', label='Sample'),
 StrCategory([...], growth=True, name='Year', label='Year'),
 Variable([4, 5, 6, 7, 8, 9, 17], name='Njet', label='N Jets'),
 Variable([0, 500, 750, 1000, 1250, 1500, 2000], name='Ht', label='$H_T$ Jets'))
```
