### PR TITLE
Drop python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.7", "3.10"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
-        - python-version: pypy-3.6
+        - python-version: pypy-3.7
           runs-on: ubuntu-latest
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ ignore =
   rapidjson/**
 
 [flake8]
-ignore = E203, E231, E501, E722, W503, B902, B950
+ignore = E203, E231, E501, E722, W503, B902, B905, B950
 select = C,E,F,W,T,B,B9,I
 per-file-ignores =
     tests/*: T

--- a/src/correctionlib/cli.py
+++ b/src/correctionlib/cli.py
@@ -86,7 +86,7 @@ def merge(console: Console, args: argparse.Namespace) -> int:
         for corr2 in cset2.corrections:
             if any(corr.name == corr2.name for corr in cset.corrections):
                 console.print(
-                    f"[red]Correction '{corr2.name}' from {file} is a duplicate"
+                    f"[red]Correction {corr2.name!r} from {file} is a duplicate"
                 )
                 return 1
             cset.corrections.append(corr2)
@@ -95,7 +95,7 @@ def merge(console: Console, args: argparse.Namespace) -> int:
                 cset.compound_corrections = []
             if any(corr.name == corr2.name for corr in cset.compound_corrections):
                 console.print(
-                    f"[red]Compound correction '{corr2.name}' from {file} is a duplicate"
+                    f"[red]Compound correction {corr2.name!r} from {file} is a duplicate"
                 )
                 return 1
             cset.compound_corrections.append(corr2)


### PR DESCRIPTION
Just for the CI for now, as github runners no longer provide it. The code should still be compatible.