### PR TITLE
Optimize Binning correction in case of uniform bins

### DIFF
--- a/include/correction.h
+++ b/include/correction.h
@@ -153,13 +153,24 @@ class HashPRNG {
 // common internal for Binning and MultiBinning
 enum class _FlowBehavior {value, clamp, error};
 
+using _NonUniformBins = std::vector<double>;
+
+struct _UniformBins {
+   double lower; // lower edge of first bin
+   double upper; // upper edge of last bin
+   std::size_t n; // number of bins
+};
+
 class Binning {
   public:
     Binning(const JSONObject& json, const Correction& context);
     const Content& child(const std::vector<Variable::Type>& values) const;
 
   private:
-    std::vector<std::tuple<double, Content>> bins_;
+    std::variant<_UniformBins, _NonUniformBins> bins_; // bin edges
+    // bin contents: contents_[i] is the value corresponding to bins_[i+1].
+    // the default value is at contents_[0]
+    std::vector<Content> contents_;
     size_t variableIdx_;
     _FlowBehavior flow_;
 };

--- a/src/correction.cc
+++ b/src/correction.cc
@@ -386,21 +386,21 @@ const Content& Binning::child(const std::vector<Variable::Type>& values) const {
 
     switch (flow_) {
       case _FlowBehavior::value:
-        if (binIdx < 0 || binIdx >= contents_.size())
-          binIdx = 0; // default value is at index 0
+        if (binIdx < 0 || binIdx >= bins->n)
+          return contents_[0u]; // the default value
         break;
       case _FlowBehavior::clamp:
-        binIdx = std::clamp(binIdx, std::size_t(1u), contents_.size() - 1u); // assuming size is always > 0
+        binIdx = std::clamp(binIdx, std::size_t(0u), bins->n - 1u); // assuming we always have at least 1 bin
         break;
       case _FlowBehavior::error:
-        if (binIdx < 0 || binIdx >= contents_.size()) {
+        if (binIdx < 0 || binIdx >= bins->n) {
           const std::string belowOrAbove = binIdx < 0 ? "below" : "above";
           const auto msg = "Index " + belowOrAbove + " bounds in Binning for input argument " + std::to_string(variableIdx_) + " value: " + std::to_string(value);
           throw std::runtime_error(std::move(msg));
         }
     }
 
-    return contents_[binIdx + 1]; // +1 because contents_[0] is the default value; actual bin contents are offset by 1
+    return contents_[binIdx + 1u]; // skipping the default value at index 0
   }
 
   // otherwise we have non-uniform binning


### PR DESCRIPTION
This patch teaches the Binning correction type to detect whether the specified binning is uniform or not. If it is, at evaluation time the is found via a simple arithmetic operation rather than via binary search.

For now I have not written new tests because the existing cases in `test_core.py` already cover uniform as well as non-uniform binning. I can add ad-hoc tests if necessary.

I have not run any benchmarks yet: I wanted to see first whether the design is green-lit first :smile: This design introduces an extra branch ("is binning uniform?") inside `Binning::child`, which runs in the hot loop. The only way I can think of removing the branch, however, is to introduce one extra correction type, `UniformBinning` -- which would require a much larger patch. Not sure if worth it?