### PR TITLE
Add UniformBinning to schemav2

### DIFF
--- a/include/correction.h
+++ b/include/correction.h
@@ -153,13 +153,24 @@ class HashPRNG {
 // common internal for Binning and MultiBinning
 enum class _FlowBehavior {value, clamp, error};
 
+using _NonUniformBins = std::vector<double>;
+
+struct _UniformBins {
+   std::size_t n; // number of bins
+   double low; // lower edge of first bin
+   double high; // upper edge of last bin
+};
+
 class Binning {
   public:
     Binning(const JSONObject& json, const Correction& context);
     const Content& child(const std::vector<Variable::Type>& values) const;
 
   private:
-    std::vector<std::tuple<double, Content>> bins_;
+    std::variant<_UniformBins, _NonUniformBins> bins_; // bin edges
+    // bin contents: contents_[i] is the value corresponding to bins_[i+1].
+    // the default value is at contents_[0]
+    std::vector<Content> contents_;
     size_t variableIdx_;
     _FlowBehavior flow_;
 };

--- a/include/correction.h
+++ b/include/correction.h
@@ -175,6 +175,12 @@ class Binning {
     _FlowBehavior flow_;
 };
 
+struct _MultiBinningAxis {
+  size_t variableIdx;
+  size_t stride;
+  std::variant<_UniformBins, _NonUniformBins> bins;
+};
+
 class MultiBinning {
   public:
     MultiBinning(const JSONObject& json, const Correction& context);
@@ -182,8 +188,9 @@ class MultiBinning {
     const Content& child(const std::vector<Variable::Type>& values) const;
 
   private:
-    // variableIdx, stride, edges
-    std::vector<std::tuple<size_t, size_t, std::vector<double>>> axes_;
+    size_t nbins(size_t dimension) const;
+
+    std::vector<_MultiBinningAxis> axes_;
     std::vector<Content> content_;
     _FlowBehavior flow_;
 };

--- a/src/correction.cc
+++ b/src/correction.cc
@@ -378,7 +378,7 @@ const Content& Binning::child(const std::vector<Variable::Type>& values) const {
 
   if ( auto *bins = std::get_if<_UniformBins>(&bins_) ) { // uniform binning
     std::size_t binIdx = bins->n * ((value - bins->low) / (bins->high - bins->low));
-    if (value < bins->low || value > bins->high) {
+    if (value < bins->low || value >= bins->high) {
       switch (flow_) {
         case _FlowBehavior::value:
             return contents_[0u]; // the default value

--- a/src/correction.cc
+++ b/src/correction.cc
@@ -337,15 +337,20 @@ Binning::Binning(const JSONObject& json, const Correction& context)
     }
     _NonUniformBins bins{std::move(edges)};
     bins_ = std::move(bins);
-  } else { // must be UniformBinning
+  } else if ( edgesObj.IsObject() ) { // UniformBinning
     const JSONObject uniformBins{edgesObj.GetObject()};
     const auto n = uniformBins.getRequired<uint64_t>("n");
+    if ( n == 0 ) {
+      throw std::runtime_error("Error when processing Binning with UniformBinning: number of bins is zero");
+    }
     if ( n != content.Size() ) {
       throw std::runtime_error("Inconsistency in Binning: number of content nodes does not match binning");
     }
     const auto low = uniformBins.getRequired<double>("low");
     const auto high = uniformBins.getRequired<double>("high");
     bins_ = _UniformBins{n, low, high};
+  } else {
+    throw std::runtime_error ("Error when processing Binning: edges are neither an array nor a UniformBinning object");
   }
 
   variableIdx_ = context.input_index(json.getRequired<std::string_view>("input"));

--- a/src/correction.cc
+++ b/src/correction.cc
@@ -427,30 +427,47 @@ const Content& Binning::child(const std::vector<Variable::Type>& values) const {
 
 MultiBinning::MultiBinning(const JSONObject& json, const Correction& context)
 {
-  const auto& edges = json.getRequired<rapidjson::Value::ConstArray>("edges");
   const auto& inputs = json.getRequired<rapidjson::Value::ConstArray>("inputs");
+
+  const auto& edges = json.getRequired<rapidjson::Value::ConstArray>("edges");
   axes_.reserve(edges.Size());
   size_t idx {0};
   for (const auto& dimension : edges) {
-    if ( ! dimension.IsArray() ) { throw std::runtime_error("Invalid MultiBinning edges array"); }
-    std::vector<double> dim_edges;
-    dim_edges.reserve(dimension.GetArray().Size());
-    for (const auto& item : dimension.GetArray()) {
-      double val = item.GetDouble();
-      if ( dim_edges.size() > 0 && dim_edges.back() >= val ) { throw std::runtime_error("binning edges are not monotone increasing"); }
-      dim_edges.push_back(val);
-    }
     const auto& input = inputs[idx];
-    if ( ! input.IsString() ) { throw std::runtime_error("invalid multibinning input type"); }
-    axes_.push_back({context.input_index(input.GetString()), 0, std::move(dim_edges)});
-    idx++;
+    if ( dimension.IsArray() ) { // non-uniform binning
+      std::vector<double> dim_edges;
+      dim_edges.reserve(dimension.GetArray().Size());
+      for (const auto& item : dimension.GetArray()) {
+        double val = item.GetDouble();
+        if ( dim_edges.size() > 0 && dim_edges.back() >= val ) { throw std::runtime_error("binning edges are not monotone increasing"); }
+        dim_edges.push_back(val);
+      }
+      if ( ! input.IsString() ) { throw std::runtime_error("invalid multibinning input type"); }
+      axes_.push_back({context.input_index(input.GetString()), 0, _NonUniformBins(std::move(dim_edges))});
+    } else if ( dimension.IsObject() ) { // UniformBinning
+      const JSONObject uniformBins{dimension.GetObject()};
+      const auto n = uniformBins.getRequired<uint64_t>("n");
+      if ( n == 0 ) {
+        auto msg = "Error when processing MultiBinning: number of bins for dimension " + std::to_string(idx) + " is zero";
+        throw std::runtime_error(std::move(msg));
+      }
+      const auto low = uniformBins.getRequired<double>("low");
+      const auto high = uniformBins.getRequired<double>("high");
+      axes_.push_back({context.input_index(input.GetString()), 0, _UniformBins{n, low, high}});
+    } else {
+      auto msg = "Error when processing MultiBinning: edges for dimension " + std::to_string(idx) + " are neither an array nor a UniformBinning object";
+      throw std::runtime_error (std::move(msg));
+    }
+    ++idx;
   }
 
   const auto& content = json.getRequired<rapidjson::Value::ConstArray>("content");
   size_t stride {1};
+  --idx; // now corresponds to the last dimension
   for (auto it=axes_.rbegin(); it != axes_.rend(); ++it) {
-    std::get<1>(*it) = stride;
-    stride *= std::get<2>(*it).size() - 1;
+    it->stride = stride;
+    stride *= nbins(idx);
+    --idx;
   }
   content_.reserve(content.Size() + 1); // + 1 for default value
   for (const auto& item : content) {
@@ -474,37 +491,73 @@ MultiBinning::MultiBinning(const JSONObject& json, const Correction& context)
   }
 }
 
+// TODO factor out logic in common with Binning::child.
+// One notable difference is that MultiBinning stores the default value at the end of content_ instead of the beginning.
 const Content& MultiBinning::child(const std::vector<Variable::Type>& values) const {
   size_t idx {0};
-  for (const auto& [variableIdx, stride, edges] : axes_) {
+  size_t localidx {0};
+
+  for (const auto& [variableIdx, stride, edgesVariant] : axes_) {
     double value = std::get<double>(values[variableIdx]);
-    auto it = std::upper_bound(std::begin(edges), std::end(edges), value);
-    if ( it == std::begin(edges) ) {
-      if ( flow_ == _FlowBehavior::value ) {
-        return *content_.rbegin();
+
+    if ( auto *bins = std::get_if<_UniformBins>(&edgesVariant) ) { // uniform bins
+      std::size_t binIdx = bins->n * ((value - bins->low) / (bins->high - bins->low));
+      if (value < bins->low || value >= bins->high) {
+        switch (flow_) {
+          case _FlowBehavior::value:
+              return content_.back(); // the default value
+          case _FlowBehavior::clamp:
+            binIdx = value < bins->low ? 0 : bins->n - 1; // assuming we always have at least 1 bin
+            break;
+          case _FlowBehavior::error:
+            const std::string belowOrAbove = value < bins->low ? "below" : "above";
+            const auto msg = "Index " + belowOrAbove + " bounds in MultiBinning for input argument " + std::to_string(variableIdx) + " value: " + std::to_string(value);
+            throw std::runtime_error(std::move(msg));
+        }
       }
-      else if ( flow_ == _FlowBehavior::error ) {
-        throw std::runtime_error("Index below bounds in MultiBinning for input argument " + std::to_string(variableIdx) + " val: " + std::to_string(value));
+      localidx = binIdx;
+    } else { // non-uniform bins
+      const auto edges = std::get<_NonUniformBins>(edgesVariant);
+      auto it = std::upper_bound(std::begin(edges), std::end(edges), value);
+      if ( it == std::begin(edges) ) {
+        if ( flow_ == _FlowBehavior::value ) {
+          return *content_.rbegin();
+        }
+        else if ( flow_ == _FlowBehavior::error ) {
+          throw std::runtime_error("Index below bounds in MultiBinning for input argument " + std::to_string(variableIdx) + " val: " + std::to_string(value));
+        }
+        else { // clamp
+          it++;
+        }
       }
-      else { // clamp
-        it++;
+      else if ( it == std::end(edges) ) {
+        if ( flow_ == _FlowBehavior::value ) {
+          return content_.back();
+        }
+        else if ( flow_ == _FlowBehavior::error ) {
+          throw std::runtime_error("Index above bounds in MultiBinning input argument" + std::to_string(variableIdx) + " val: " + std::to_string(value));
+        }
+        else { // clamp
+          it--;
+        }
       }
+      localidx = std::distance(std::begin(edges), it) - 1;
     }
-    else if ( it == std::end(edges) ) {
-      if ( flow_ == _FlowBehavior::value ) {
-        return *content_.rbegin();
-      }
-      else if ( flow_ == _FlowBehavior::error ) {
-        throw std::runtime_error("Index above bounds in MultiBinning input argument" + std::to_string(variableIdx) + " val: " + std::to_string(value));
-      }
-      else { // clamp
-        it--;
-      }
-    }
-    size_t localidx = std::distance(std::begin(edges), it) - 1;
+
     idx += localidx * stride;
   }
+
   return content_.at(idx);
+}
+
+size_t MultiBinning::nbins(size_t dimension) const
+{
+  if ( const auto *bins = std::get_if<_UniformBins>(&axes_[dimension].bins) )
+    return bins->n; // using uniform bins
+
+  // otherwise we must have non-uniform bins
+  const auto &bins = std::get<_NonUniformBins>(axes_[dimension].bins);
+  return bins.size() - 1;
 }
 
 Category::Category(const JSONObject& json, const Correction& context)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -708,7 +708,7 @@ def test_category():
 def test_binning():
     def binning(flow, uniform=True):
         if uniform:
-            edges = schema.UniformBinning(n=2, low=0., high=3.)
+            edges = schema.UniformBinning(n=2, low=0.0, high=3.0)
         else:
             edges = [0.0, 1.0, 3.0]
         cset = wrap(


### PR DESCRIPTION
When defining a Binning, the `edges` attribute can now be either a list of floats (like before) or an instance of UniformBinning(n, low, high). When using the latter option, the Binning correction is optimized to use a simple arithmetic formula rather than binary search to look up the bin index.

This is a fresh (better) take on #181 .

Example usage:

```python
from correctionlib import schemav2 as schema

if __name__ == "__main__":
    corr = schema.Correction(
        name="test",
        version=2,
        inputs=[schema.Variable(name="x", type="real")],
        output=schema.Variable(name="a scale", type="real"),
        data=schema.Binning(
            nodetype="binning",
            input="x",
            edges=schema.UniformBinning(n=2, low=0., high=2.),
            content=[1.0, 2.0],
            flow="error",
        ),
    )
    e = corr.to_evaluator()
    print(e.evaluate(0.5))
    print(e.evaluate(1.0))
    print(e.evaluate(3.0)) # errors out
```

To do:
- [x] add tests
- [x] add support for MultiBinning
