### PR TITLE
Remove some unneeded build dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,10 @@
 [build-system]
 requires = [
-    "wheel",
     "setuptools>=42",
     "setuptools_scm[toml]>=3.4",
     "pybind11>=2.6.1",
     "scikit-build>=0.12",
-    "cmake>=3.11.0",
-    "make"
+    "cmake>=3.11.0"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
1. make on PyPI does not provide access to make build tool
2. wheel dependency is declared by setuptools automatically

To clarify the second point, PEP 517 provides [a way](https://peps.python.org/pep-0517/#get-requires-for-build-wheel) for build backends like setuptools to express additional dependencies that they need for either building a wheel or an sdist. If we let setuptools do this for us, `wheel` will only be included as a dependency when building wheels and not an sdist.

My motivation is from working on migrating Python packages in [nixpkgs](https://github.com/NixOS/nixpkgs) to use [`build`](https://pypa-build.readthedocs.io/en/latest/), which validates that all the build dependencies declared are present, and I do not want to package [make](https://pypi.org/project/make/).