### PR TITLE
Fix py3.6 wheel test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
 test =
   pytest >=4.6
   scipy
-  awkward >=2
+  awkward >=2;python_version>"3.7"
   dask-awkward;python_version>"3.7"
 dev =
   pytest >=4.6


### PR DESCRIPTION
FYI @lgray awkward 2 doesn't have py3.6 wheels, wasn't caught in regular CI