### PR TITLE
Move away from deprecated pkg_resources

### DIFF
--- a/src/correctionlib/__init__.py
+++ b/src/correctionlib/__init__.py
@@ -2,14 +2,11 @@ import sys
 
 if sys.platform.startswith("win32"):
     import ctypes
-    import os.path
 
-    import pkg_resources
+    import importlib.resources
 
     ctypes.CDLL(
-        pkg_resources.resource_filename(
-            "correctionlib", os.path.join("lib", "correctionlib.dll")
-        )
+        str(importlib.resources.files("correctionlib") / "lib" / "correctionlib.dll")
     )
 
 

--- a/src/correctionlib/__init__.py
+++ b/src/correctionlib/__init__.py
@@ -3,11 +3,9 @@ import sys
 if sys.platform.startswith("win32"):
     import ctypes
 
-    import importlib.resources
+    from .util import this_module_path
 
-    ctypes.CDLL(
-        str(importlib.resources.files("correctionlib") / "lib" / "correctionlib.dll")
-    )
+    ctypes.CDLL(str(this_module_path() / "lib" / "correctionlib.dll"))
 
 
 from .binding import register_pyroot_binding

--- a/src/correctionlib/binding.py
+++ b/src/correctionlib/binding.py
@@ -1,25 +1,19 @@
 def register_pyroot_binding() -> None:
-    import os.path
     import sys
 
-    import pkg_resources
+    import importlib.resources
     from cppyy import gbl
+
+    base_path = importlib.resources.files("correctionlib")
+    lib = base_path / "lib"
 
     # maybe not the most robust solution?
     if sys.platform.startswith("win32"):
-        lib = pkg_resources.resource_filename(
-            "correctionlib", os.path.join("lib", "correctionlib.dll")
-        )
+        lib = lib / "correctionlib.dll"
     elif sys.platform.startswith("darwin"):
-        lib = pkg_resources.resource_filename(
-            "correctionlib", os.path.join("lib", "libcorrectionlib.dylib")
-        )
+        lib = lib / "libcorrectionlib.dylib"
     else:
-        lib = pkg_resources.resource_filename(
-            "correctionlib", os.path.join("lib", "libcorrectionlib.so")
-        )
+        lib = lib / "libcorrectionlib.so"
     gbl.gSystem.Load(lib)
-    gbl.gInterpreter.AddIncludePath(
-        pkg_resources.resource_filename("correctionlib", "include")
-    )
+    gbl.gInterpreter.AddIncludePath(base_path / "include")
     gbl.gROOT.ProcessLine('#include "correction.h"')

--- a/src/correctionlib/binding.py
+++ b/src/correctionlib/binding.py
@@ -1,10 +1,11 @@
 def register_pyroot_binding() -> None:
     import sys
 
-    import importlib.resources
     from cppyy import gbl
 
-    base_path = importlib.resources.files("correctionlib")
+    from .util import this_module_path
+
+    base_path = this_module_path()
     lib = base_path / "lib"
 
     # maybe not the most robust solution?

--- a/src/correctionlib/cli.py
+++ b/src/correctionlib/cli.py
@@ -130,10 +130,11 @@ def setup_merge(subparsers: Any) -> None:
 
 
 def config(console: Console, args: argparse.Namespace) -> int:
-    import pkg_resources
+    import importlib.resources
 
-    incdir = pkg_resources.resource_filename("correctionlib", "include")
-    libdir = pkg_resources.resource_filename("correctionlib", "lib")
+    base_dir = importlib.resources.files("correctionlib")
+    incdir = base_dir / "include"
+    libdir = base_dir / "lib"
     out = []
     if args.version:
         out.append(correctionlib.version.version)
@@ -148,9 +149,7 @@ def config(console: Console, args: argparse.Namespace) -> int:
     if args.rpath:
         out.append(f"-Wl,-rpath,{libdir}")
     if args.cmake:
-        out.append(
-            f"-Dcorrectionlib_DIR={pkg_resources.resource_filename('correctionlib', 'cmake')}"
-        )
+        out.append(f"-Dcorrectionlib_DIR={base_dir / 'cmake'}")
     console.out(" ".join(out), highlight=False)
     return 0
 

--- a/src/correctionlib/cli.py
+++ b/src/correctionlib/cli.py
@@ -130,20 +130,20 @@ def setup_merge(subparsers: Any) -> None:
 
 
 def config(console: Console, args: argparse.Namespace) -> int:
-    import importlib.resources
+    from .util import this_module_path
 
-    base_dir = importlib.resources.files("correctionlib")
+    base_dir = this_module_path()
     incdir = base_dir / "include"
     libdir = base_dir / "lib"
     out = []
     if args.version:
         out.append(correctionlib.version.version)
     if args.incdir:
-        out.append(incdir)
+        out.append(str(incdir))
     if args.cflags:
         out.append(f"-std=c++17 -I{incdir}")
     if args.libdir:
-        out.append(libdir)
+        out.append(str(libdir))
     if args.ldflags:
         out.append(f"-L{libdir} -lcorrectionlib")
     if args.rpath:

--- a/src/correctionlib/util.py
+++ b/src/correctionlib/util.py
@@ -1,0 +1,15 @@
+import pathlib
+import sys
+
+
+def this_module_path() -> pathlib.Path:
+    # TODO: this package could be a zipball, in which case these paths are temporary
+    # We could warn but there is an almost negligible chance this is the case
+    if sys.version_info < (3, 9):
+        # use deprecated API
+        import pkg_resources
+
+        return pathlib.Path(pkg_resources.resource_filename("correctionlib", ""))
+    import importlib.resources
+
+    return importlib.resources.files("correctionlib")


### PR DESCRIPTION
I followed the migration guide:
https://importlib-resources.readthedocs.io/en/latest/migration.html.

Unfortunately the new APIs are only available as of Python 3.9. There are other ones, also in `importlib.resources`, that are available since 3.7 but are deprecated and 3.11.

As a rationale for the migration, see https://github.com/cms-nanoAOD/correctionlib/issues/211.