### PR TITLE
Add -Wextra -Wpedantic -Wall to C++ compilation options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     cmake_install_dir="src",
     cmake_args=[
         f"-DCORRECTIONLIB_VERSION:STRING={get_version()}",
-        "-DCMAKE_CXX_OPTIONS='-Wextra -Wpedantic -Wall'",
+        "-DCMAKE_CXX_OPTIONS='-Wextra -Wpedantic -Wall -Werror'",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,8 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     cmake_install_dir="src",
-    cmake_args=[f"-DCORRECTIONLIB_VERSION:STRING={get_version()}"],
+    cmake_args=[
+        f"-DCORRECTIONLIB_VERSION:STRING={get_version()}",
+        "-DCMAKE_CXX_OPTIONS='-Wextra -Wpedantic -Wall'",
+    ],
 )

--- a/src/correction.cc
+++ b/src/correction.cc
@@ -52,6 +52,8 @@ class correction::JSONObject {
     const rapidjson::Value& getRequiredValue(const char * key) const {
       const auto it = json_.FindMember(key);
       if ( it != json_.MemberEnd() ) {
+        int x = 42.f;
+        x + 42;
         return it->value;
       }
       throw std::runtime_error(


### PR DESCRIPTION
This _would_ be desirable, if the warnings then actually appeared in the build output. I'm probably doing something wrong.