### PR TITLE
Make interfaces of C++ correction types more uniform

### DIFF
--- a/include/correction.h
+++ b/include/correction.h
@@ -188,7 +188,7 @@ struct _UniformBins {
 class Binning {
   public:
     Binning(const JSONObject& json, const Correction& context);
-    const Content& child(const std::vector<Variable::Type>& values) const;
+    double evaluate(const std::vector<Variable::Type>& values) const;
 
   private:
     std::variant<_UniformBins, _NonUniformBins> bins_; // bin edges
@@ -209,7 +209,7 @@ class MultiBinning {
   public:
     MultiBinning(const JSONObject& json, const Correction& context);
     size_t ndimensions() const { return axes_.size(); };
-    const Content& child(const std::vector<Variable::Type>& values) const;
+    double evaluate(const std::vector<Variable::Type>& values) const;
 
   private:
     size_t nbins(size_t dimension) const;
@@ -222,7 +222,7 @@ class MultiBinning {
 class Category {
   public:
     Category(const JSONObject& json, const Correction& context);
-    const Content& child(const std::vector<Variable::Type>& values) const;
+    double evaluate(const std::vector<Variable::Type>& values) const;
 
   private:
     typedef std::map<int, Content> IntMap;


### PR DESCRIPTION
Before this commit, most correction types implemented an `evaluate` method while some implemented a `child` method. When walking a correction's compute graph, the `node_evaluate` visitor had to know which ones required recursive visiting and which did not.

With this patch, all correction types implement `evaluate`. This simplifies the implementation of the `node_evaluate` visitor considerably and keeps the logic related to the handling of each type of correction local to the corrections themselves.

@nsmith- just an idea, feel free to close if you don't like the direction.