### PR TITLE
feat: add dask_awkward wrapper to Correction and CompoundCorrection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ test =
   scipy
   awkward >=2.2.2;python_version>"3.7"
   awkward <2;python_version<="3.7"
-  dask-awkward;python_version>"3.7"
+  dask-awkward >=2024.1.1;python_version>"3.7"
 dev =
   pytest >=4.6
   pre-commit

--- a/src/correctionlib/highlevel.py
+++ b/src/correctionlib/highlevel.py
@@ -218,6 +218,13 @@ class Correction:
         self, *args: Union["numpy.ndarray[Any, Any]", str, int, float]
     ) -> Union[float, "numpy.ndarray[Any, numpy.dtype[numpy.float64]]"]:
         # TODO: create a ufunc with numpy.vectorize in constructor?
+        if any(str(type(arg)).startswith("<class 'dask.array.") for arg in args):
+            raise TypeError(
+                "correctionlib does not yet handle dask.array collections, "
+                "if you require this functionality (i.e. you cannot do do "
+                "not want to use dask_awkward/awkward arrays) please open an "
+                "issue at https://github.com/cms-nanoAOD/correctionlib/issues."
+            )
         try:
             vargs = [
                 numpy.asarray(arg)
@@ -289,6 +296,13 @@ class CompoundCorrection:
         self, *args: Union["numpy.ndarray[Any, Any]", str, int, float]
     ) -> Union[float, "numpy.ndarray[Any, numpy.dtype[numpy.float64]]"]:
         # TODO: create a ufunc with numpy.vectorize in constructor?
+        if any(str(type(arg)).startswith("<class 'dask.array.") for arg in args):
+            raise TypeError(
+                "correctionlib does not yet handle dask.array collections, "
+                "if you require this functionality (i.e. you cannot do do "
+                "not want to use dask_awkward/awkward arrays) please open an "
+                "issue at https://github.com/cms-nanoAOD/correctionlib/issues."
+            )
         try:
             vargs = [
                 numpy.asarray(arg)

--- a/src/correctionlib/highlevel.py
+++ b/src/correctionlib/highlevel.py
@@ -11,7 +11,8 @@ from packaging import version
 import correctionlib._core
 import correctionlib.version
 
-_version_two = version.parse("2")
+_min_version_ak = version.parse("2.0.0")
+_min_version_dak = version.parse("2024.1.1")
 
 
 def open_auto(filename: str) -> str:
@@ -58,9 +59,9 @@ def _call_as_numpy(
 ) -> Any:
     import awkward
 
-    if version.parse(awkward.__version__) < _version_two:
+    if version.parse(awkward.__version__) < _min_version_ak:
         raise RuntimeError(
-            f"""imported awkward is version {awkward.__version__} < 2.0.0
+            f"""imported awkward is version {awkward.__version__} < {str(_min_version_ak)}
             If you cannot upgrade, try doing: ak.flatten(arrays) -> result = correction(arrays) -> ak.unflatten(result, counts)
             """
         )
@@ -143,6 +144,14 @@ def _wrap_dask_awkward(
 ) -> Any:
     import dask.delayed
     import dask_awkward
+
+    if version.parse(dask_awkward.__version__) < _min_version_dak:
+        raise RuntimeError(
+            f"""imported dask_awkward is version {dask_awkward.__version__} < {str(_min_version_dak)}
+            This version of dask_awkward includes several useful bugfixes and functionality extensions.
+            Please upgrade dask_awkward.
+            """
+        )
 
     if not hasattr(correction, "_delayed_correction"):
         setattr(  # noqa: B010

--- a/src/correctionlib/highlevel.py
+++ b/src/correctionlib/highlevel.py
@@ -221,7 +221,7 @@ class Correction:
         if any(str(type(arg)).startswith("<class 'dask.array.") for arg in args):
             raise TypeError(
                 "correctionlib does not yet handle dask.array collections, "
-                "if you require this functionality (i.e. you cannot do do "
+                "if you require this functionality (i.e. you cannot or do "
                 "not want to use dask_awkward/awkward arrays) please open an "
                 "issue at https://github.com/cms-nanoAOD/correctionlib/issues."
             )
@@ -299,7 +299,7 @@ class CompoundCorrection:
         if any(str(type(arg)).startswith("<class 'dask.array.") for arg in args):
             raise TypeError(
                 "correctionlib does not yet handle dask.array collections, "
-                "if you require this functionality (i.e. you cannot do do "
+                "if you require this functionality (i.e. you cannot or do "
                 "not want to use dask_awkward/awkward arrays) please open an "
                 "issue at https://github.com/cms-nanoAOD/correctionlib/issues."
             )

--- a/src/correctionlib/highlevel.py
+++ b/src/correctionlib/highlevel.py
@@ -220,8 +220,8 @@ class Correction:
         # TODO: create a ufunc with numpy.vectorize in constructor?
         if any(str(type(arg)).startswith("<class 'dask.array.") for arg in args):
             raise TypeError(
-                "correctionlib does not yet handle dask.array collections, "
-                "if you require this functionality (i.e. you cannot or do "
+                "Correctionlib does not yet handle dask.array collections. "
+                "If you require this functionality (i.e. you cannot or do "
                 "not want to use dask_awkward/awkward arrays) please open an "
                 "issue at https://github.com/cms-nanoAOD/correctionlib/issues."
             )
@@ -298,7 +298,7 @@ class CompoundCorrection:
         # TODO: create a ufunc with numpy.vectorize in constructor?
         if any(str(type(arg)).startswith("<class 'dask.array.") for arg in args):
             raise TypeError(
-                "correctionlib does not yet handle dask.array collections, "
+                "Correctionlib does not yet handle dask.array collections. "
                 "if you require this functionality (i.e. you cannot or do "
                 "not want to use dask_awkward/awkward arrays) please open an "
                 "issue at https://github.com/cms-nanoAOD/correctionlib/issues."

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -96,8 +96,7 @@ def test_highlevel_dask(cset):
     x = awkward.unflatten(numpy.ones(6), [3, 2, 1])
     dx = dask_awkward.from_awkward(x, 3)
 
-    evaluate = dask_awkward.map_partitions(
-        sf.evaluate,
+    evaluate = sf.evaluate(
         dx,
         1.0,
     )


### PR DESCRIPTION
Also add awkward wrapper to CompoundCorrection.

This PR lets us pass dask_awkward.Array into correctionlib corrections.
It does the wrapping of the correction into a delayed object and map_partitions call internally now.

```python3
evaluate = sf.evaluate(
    dx,
    1.0,
)
```

Is significantly cleaner than the `map_partitions` version.