### PR TITLE
Re-enable rapidjson::kParseNanAndInfFlag for backwards-compatibility

### DIFF
--- a/src/correction.cc
+++ b/src/correction.cc
@@ -802,14 +802,14 @@ std::unique_ptr<CorrectionSet> CorrectionSet::from_file(const std::string& fn) {
 #ifdef WITH_ZLIB
     gzFile_s* fpz = gzopen(fn.c_str(), "r");
     rapidjson::GzFileReadStream is(fpz, readBuffer, sizeof(readBuffer));
-    ok = json.ParseStream(is);
+    ok = json.ParseStream<rapidjson::kParseNanAndInfFlag>(is);
     gzclose(fpz);
 #else
     throw std::runtime_error("Gzip-compressed JSON files are only supported if ZLIB is found when the package is built");
 #endif
   } else {
     rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
-    ok = json.ParseStream(is);
+    ok = json.ParseStream<rapidjson::kParseNanAndInfFlag>(is);
     fclose(fp);
   }
   if (!ok) {
@@ -824,7 +824,7 @@ std::unique_ptr<CorrectionSet> CorrectionSet::from_file(const std::string& fn) {
 
 std::unique_ptr<CorrectionSet> CorrectionSet::from_string(const char * data) {
   rapidjson::Document json;
-  rapidjson::ParseResult ok = json.Parse(data);
+  rapidjson::ParseResult ok = json.Parse<rapidjson::kParseNanAndInfFlag>(data);
   if (!ok) {
     throw std::runtime_error(
         std::string("JSON parse error: ") + rapidjson::GetParseError_En(ok.Code())


### PR DESCRIPTION
This is so the evaluator can continue to read json produced pre-v2.6 The schema validator will continue to test for float infinity and warn to migrate to string infinity.
The alternative would be to migrate all json to string infinity, but that would not be readable by older evaluators, which is more of a usability issue than the lack of standards-compliance in old json files, for now.

Closes #247 