### PR TITLE
Make the help message slightly more clear

### DIFF
--- a/src/correctionlib/cli.py
+++ b/src/correctionlib/cli.py
@@ -219,7 +219,7 @@ def main() -> int:
         return retcode
 
     help = parser.format_help() + "\n"
-    help += "Subcommand usage:\n"
+    help += "Subcommand usage (specify -h for more detail):\n"
     for command in all_commands:
         help += command.format_usage()
     console.out(help, highlight=False)


### PR DESCRIPTION
On invocation without any argument we now get:
```
usage: correction [-h] [--width WIDTH] [--html HTML] {validate,summary,merge,config} ...

Command-line interface to correctionlib.

positional arguments:
  {validate,summary,merge,config}
    validate            Check if all files are valid
    summary             Print a summmary of the corrections
    merge               Merge one or more correction files and print to stdout
    config              Configuration and linking information

options:
  -h, --help            show this help message and exit
  --width WIDTH         Rich output width
  --html HTML           Save terminal output to an HTML file

Subcommand usage (specify -h for more detail):
usage: correction validate [-h] [--quiet] [--failfast] [--version VERSION] [--ignore-float-inf] FILE [FILE ...]
usage: correction summary [-h] FILE [FILE ...]
usage: correction merge [-h] [-f {compact,indented,pretty}] FILE [FILE ...]
usage: correction config [-h] [-v] [--incdir] [--cflags] [--libdir] [--ldflags] [--rpath] [--cmake]
```