### PR TITLE
Support using system CMake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "setuptools_scm[toml]>=3.4",
     "pybind11>=2.6.1",
     "scikit-build>=0.12",
-    "cmake>=3.11.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,20 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/nsmith-/correctionlib for details.
 
+import shutil
+
 from setuptools import find_packages
 from setuptools_scm import get_version
 from skbuild import setup
+
+setup_requires = []
+if shutil.which("cmake") is None:
+    setup_requires += ["cmake>=3.11.0"]
 
 setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     cmake_install_dir="src",
     cmake_args=[f"-DCORRECTIONLIB_VERSION:STRING={get_version()}"],
+    setup_requires=setup_requires,
 )


### PR DESCRIPTION
Supporting using the system version of CMake instead of forcing `cmake` package from PyPI, when the former is available.  Using system version of CMake allows users to benefit from better portability due to downstream patching of CMake.  It also avoids an unnecessary dependency.