### PR TITLE
Add `flow: wrap` option to handle circular axes 

### DIFF
--- a/include/correction.h
+++ b/include/correction.h
@@ -175,7 +175,7 @@ class HashPRNG {
 };
 
 // common internal for Binning and MultiBinning
-enum class _FlowBehavior {value, clamp, error};
+enum class _FlowBehavior {value, clamp, error, wrap};
 
 using _NonUniformBins = std::vector<double>;
 

--- a/src/correctionlib/schemav2.py
+++ b/src/correctionlib/schemav2.py
@@ -232,7 +232,7 @@ class Binning(Model):
         description="Edges of the binning, either as a list of monotonically increasing floats or as an instance of UniformBinning. edges[i] <= x < edges[i+1] => f(x, ...) = content[i](...)"
     )
     content: List[Content]
-    flow: Union[Content, Literal["clamp", "error"]] = Field(
+    flow: Union[Content, Literal["clamp", "error", "wrap"]] = Field(
         description="Overflow behavior for out-of-bounds values"
     )
 
@@ -287,7 +287,7 @@ class MultiBinning(Model):
         to the element at i0 in dimension 0, i1 in dimension 1, etc. and d0 = len(edges[0])-1, etc.
     """
     )
-    flow: Union[Content, Literal["clamp", "error"]] = Field(
+    flow: Union[Content, Literal["clamp", "error", "wrap"]] = Field(
         description="Overflow behavior for out-of-bounds values"
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -751,6 +751,17 @@ def test_binning():
         assert corr.evaluate(2.9) == 2.0
         assert corr.evaluate(3.0) == 42.0
 
+        corr = binning(flow="wrap", uniform=use_uniform_binning)
+        assert corr.evaluate(-3.0) == 1.0
+        assert corr.evaluate(-2.9) == 1.0
+        assert corr.evaluate(-1.0) == 2.0
+        assert corr.evaluate(0.0) == 1.0
+        assert corr.evaluate(1.0) == 1.0 if use_uniform_binning else 2.0
+        assert corr.evaluate(2.9) == 2.0
+        assert corr.evaluate(3.0) == 1.0
+        assert corr.evaluate(4.6) == 2.0
+        assert corr.evaluate(6.1) == 1.0
+
     def multibinning(flow, uniform=True):
         if uniform:
             edges_x = schema.UniformBinning(n=2, low=0.0, high=3.0)


### PR DESCRIPTION
This PR implements a new `wrap` option for handling over-/underflow values on circular axes. A typical use case is for corrections that use the azimuthal angle *φ* as in input, which is unique up to integer multiples of 2π. This should alleviate issues with inputs landing outside the axis interval due to limited float precision, in which case `flow: error` would unnecessarily break workflows and the other existing flow behaviors like `clamp` or a fixed value may give slightly wrong results.

The implementation is analogous to the bin lookup on circular axes, as implemented in *boost-histogram* (see [code](https://github.com/boostorg/histogram/blob/66842660c0bad0ce80c6db5fe68c7d7e4ec00be4/include/boost/histogram/axis/regular.hpp#L310-L316)).

Happy to hear your feedback!