### PR TITLE
ci: add sentinel tests task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,10 @@ jobs:
       - name: Test package
         shell: bash -l {0}
         run: python -m pytest -ra
+
+  pass:
+    name: All tests passed
+    needs: [checks, checkroot]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All jobs passed"


### PR DESCRIPTION
Just adding a sentinel ci task that needs all the testing tasks so that in github settings only this task can be required to pass.