### PR TITLE
chore: turn on dependabot monthly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,4 @@ updates:
     schedule:
       interval: "monthly"
     commit-message:
-      # Prefix all commit messages with "npm: "
       prefix: "ci: "


### PR DESCRIPTION
so that we don't have massive version skew to available python versions anymore.