### PR TITLE
Use upstream lwtnn submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/Cyan4973/xxHash.git
 [submodule "lwtnn"]
 	path = lwtnn
-	url = https://github.com/sbein/lwtnn.git
+	url = https://github.com/lwtnn/lwtnn.git


### PR DESCRIPTION
Switch lwtnn submodule URL from fork to upstream.

No change to pinned commit; only updates the source URL.