### PR TITLE
Skip tests for manylinux_aarch64 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ write_to = "src/correctionlib/version.py"
 skip = ["cp3{9,10}*-win_arm64"]
 test-groups = ["test"]
 test-command = "python -m pytest {package}/tests"
-test-skip = ["*-musllinux_*", "cp3{10,11,12}-win32", "cp*-win_arm64"]
+test-skip = ["*-musllinux_*", "cp3{10,11,12}-win32", "cp*-win_arm64", "cp*-manylinux_aarch64"]
 
 [tool.cibuildwheel.environment]
 # this makes sure that we build only on platforms that have a corresponding numpy wheel


### PR DESCRIPTION
As we see small floating point rounding discrepancies in lwtnn on this platform. Related to #35 

In the [wheel build](https://github.com/cms-nanoAOD/correctionlib/actions/runs/27582720385/job/81546393204) on ubuntu-24.04-arm for we have a test failure:
```
[3](https://github.com/cms-nanoAOD/correctionlib/actions/runs/27582720385/job/81546393204#step:3:2624)
  =================================== FAILURES ===================================
  ______________________________ test_lwtnn_example ______________________________
  
      def test_lwtnn_example():
          cset = CorrectionSet.from_file(str(LWTNN_TEST_FIXTURE))
          corr = cset["electron_fastsim_sf"]
      
          gen_pt = 15.0
          gen_eta = 0.4
          gen_phi = 2.1
          gen_iso = 1e-3
          sf = corr.evaluate(
              gen_pt,
              gen_eta,
              gen_phi,
              gen_iso,
          )
  >       assert sf == 0.95186825355646787
  E       assert 0.9518682535564678 == 0.9518682535564679
  
  /project/tests/test_lwtnn.py:41: AssertionError
```
so it seems lwtnn is sensitive to platform-dependent float rounding.