### PR TITLE
Fix free-threaded cross-compile builds by stating the Python ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,19 @@ option(BUILD_DEMO "Build demo program" ON)
 
 set(PKG_INSTALL "correctionlib") ## python package name
 
+# When cross-compiling, pybind11 asks FindPython for Development.Module without the
+# Interpreter component, so CMake (>=4.4) has nothing to deduce the free-threaded ABI
+# from and rejects the GIL-disabled headers with "missing: Development.Module".
+# Older CMake accepted them but derived a SOABI without the "t" flag. State the ABI
+# explicitly when the headers we were pointed at are free-threaded.
+if(NOT DEFINED Python_FIND_ABI AND EXISTS "${Python_INCLUDE_DIR}/pyconfig.h")
+  file(STRINGS "${Python_INCLUDE_DIR}/pyconfig.h" PY_GIL_DISABLED_DEFINE
+    REGEX "^[ \t]*#[ \t]*define[ \t]+Py_GIL_DISABLED[ \t]+1")
+  if(PY_GIL_DISABLED_DEFINE)
+    set(Python_FIND_ABI "OFF;ANY;ANY;ON")
+  endif()
+endif()
+
 include(FetchContent)
 FetchContent_Declare(pybind11
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/pybind11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,16 @@ if(MSVC)
   target_compile_options(correctionlib PRIVATE /Zc:__cplusplus /utf-8)
 else()
   target_compile_options(correctionlib PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  # cpp-peglib declares operator"" _ with the whitespace C++23 deprecates, which
+  # recent clang diagnoses and -Werror makes fatal. Upstream fixed it in v1.14.0,
+  # but every release carrying that fix has dropped the parser.log API we use, so
+  # silence it here instead. Probe the positive form: compilers accept unknown
+  # -Wno-* options silently, so checking that directly proves nothing.
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-Wdeprecated-literal-operator HAVE_WDEPRECATED_LITERAL_OPERATOR)
+  if(HAVE_WDEPRECATED_LITERAL_OPERATOR)
+    target_compile_options(correctionlib PRIVATE -Wno-deprecated-literal-operator)
+  endif()
 endif()
 target_link_libraries(correctionlib PRIVATE lwtnn-stat)
 if(ZLIB_FOUND)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ ignore = [
 [tool.mypy]
 python_version = "3.9"
 files = ["src"]
+follow_imports_for_stubs = true
 
 [[tool.mypy.overrides]]
 module = ["awkward.*", "uproot.*"]
@@ -119,6 +120,13 @@ follow_untyped_imports = true
 [[tool.mypy.overrides]]
 module = ["cppyy.*", "scipy.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# numpy's stubs use PEP 695 "type" statements, which mypy refuses to parse while we
+# target python_version 3.9, so skip them; follow_imports_for_stubs above is what
+# makes the skip apply to .pyi files at all
+module = ["numpy", "numpy.*"]
+follow_imports = "skip"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
> [!NOTE]
> This description is agent-generated text, written by Claude Opus 5 via Claude Code.

The conda-forge `cp314t` (free-threaded 3.14) builds fail on exactly the three
cross-compiled targets — `linux-aarch64`, `linux-ppc64le`, `osx-arm64` — with

```
CMake Error at $BUILD_PREFIX/share/cmake-4.4/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find Python (missing: Development.Module) (found suitable version
  "3.14.6", minimum required is "3.8")
```

See conda-forge/correctionlib-feedstock#37. Native `cp314t` builds pass, and so do
all the cross-compiled GIL-enabled variants, so it takes cross-compiling *and*
free-threading together.

### Cause

1. conda's `CMAKE_ARGS` passes `-DCMAKE_SYSTEM_NAME=Linux`, so `CMAKE_CROSSCOMPILING` is true.
2. pybind11 3.0 honours CMP0190 (enabled here because our policy range reaches 4.1)
   and drops the `Interpreter` component when cross-compiling.
3. CMake 4.4's `FindPython` deduces the free-threaded ABI from the interpreter. With
   no interpreter it falls back to GIL-enabled and rejects the `python3.14t` headers
   that scikit-build-core points it at — the version still gets read out of
   `patchlevel.h`, hence the "found suitable version 3.14.6" in the same message.

Nothing is wrong on the conda-forge side, and cibuildwheel is unaffected because it
never sets `CMAKE_SYSTEM_NAME`.

Worth noting that CMake <= 4.3 did not error here — it silently computed a SOABI
without the `t` flag (`cpython-314-linux-aarch64`), i.e. a mis-named extension
module. 4.4 turned that into a hard error.

### Fix

State the ABI explicitly when the headers we were handed are free-threaded, before
pybind11 runs `find_package(Python)`.

### Testing

Reproduced locally with CMake 4.4.0 (conda-forge uses 4.4.1), a free-threaded
CPython 3.14.3, and a toolchain file setting only `CMAKE_SYSTEM_NAME`/
`CMAKE_SYSTEM_PROCESSOR` to trip `CMAKE_CROSSCOMPILING`:

- before: `Could NOT find Python (missing: Development.Module)`, same as CI
- after: `found components: Development.Module Development.Embed`,
  `Python_SOABI: cpython-314t-darwin`, and `_core.cpython-314t-darwin.so` builds
  and links
- unchanged: native free-threaded builds, and plain 3.14 with no hints (the
  `pyconfig.h` guard doesn't fire)

### Follow-up

The cpp-peglib suppression here is a workaround, not a fix; #354 tracks bumping the
submodule and migrating off the removed `parser.log` API.
