### PR TITLE
perf: drop the redundant awkward.broadcast_arrays before awkward.transform

### DIFF
--- a/src/correctionlib/highlevel.py
+++ b/src/correctionlib/highlevel.py
@@ -122,8 +122,6 @@ def _wrap_awkward(
             non_array_args.append(arg)
             non_array_indices.append(iarg)
 
-    array_args = awkward.broadcast_arrays(*array_args)
-
     arg_indices = array_indices + non_array_indices
 
     tocall = partial(
@@ -133,6 +131,8 @@ def _wrap_awkward(
         arg_indices=arg_indices,
     )
 
+    # awkward.transform broadcasts its inputs itself, so broadcasting them first only
+    # does that work twice (and the explicit pass was the larger half of the wrapper's cost)
     return awkward.transform(tocall, *array_args)
 
 

--- a/tests/test_highlevel_broadcast.py
+++ b/tests/test_highlevel_broadcast.py
@@ -1,0 +1,127 @@
+"""awkward arguments are broadcast once, by awkward.transform itself
+
+The wrapper used to call awkward.broadcast_arrays before awkward.transform; transform already
+broadcasts its inputs, so the explicit pass only doubled the work. These tests pin that the
+shapes the explicit pass handled still come out the same without it.
+"""
+
+import awkward
+import numpy
+import pytest
+
+import correctionlib
+from correctionlib import schemav2 as model
+
+
+@pytest.fixture
+def sf():
+    """``2*a + b``, so every element's result depends on that element's own inputs"""
+    return correctionlib.CorrectionSet(
+        model.CorrectionSet(
+            schema_version=model.VERSION,
+            corrections=[
+                model.Correction(
+                    name="two",
+                    version=1,
+                    inputs=[
+                        model.Variable(name="a", type="real"),
+                        model.Variable(name="b", type="real"),
+                    ],
+                    output=model.Variable(name="o", type="real"),
+                    data=model.Formula(
+                        nodetype="formula",
+                        expression="2.0*x + y",
+                        parser="TFormula",
+                        variables=["a", "b"],
+                    ),
+                )
+            ],
+        )
+    )["two"]
+
+
+def jagged(values, counts):
+    return awkward.unflatten(numpy.asarray(values, dtype=numpy.float64), counts)
+
+
+def assert_identical(left, right):
+    """Values, None mask and type, all the way down"""
+    assert awkward.to_list(left) == awkward.to_list(right)
+    assert str(awkward.type(left)) == str(awkward.type(right))
+    assert left.layout.form.to_json() == right.layout.form.to_json()
+
+
+@pytest.mark.parametrize(
+    "make_pair",
+    [
+        pytest.param(
+            lambda: (
+                jagged(numpy.arange(9), [4, 0, 3, 2]),
+                awkward.Array(numpy.arange(4.0)),
+            ),
+            id="jagged-against-flat",
+        ),
+        pytest.param(
+            lambda: (
+                awkward.Array(numpy.arange(9.0)),
+                awkward.Array(numpy.array([100.0])),
+            ),
+            id="length-one",
+        ),
+        pytest.param(
+            lambda: (
+                jagged(numpy.arange(9), [4, 0, 3, 2]),
+                awkward.mask(
+                    jagged(numpy.arange(100, 109), [4, 0, 3, 2]),
+                    jagged(numpy.arange(9), [4, 0, 3, 2]) % 2 == 0,
+                ),
+            ),
+            id="option-against-plain",
+        ),
+    ],
+)
+def test_arguments_needing_broadcast_match_the_explicit_pass(sf, make_pair):
+    a, b = make_pair()
+    direct = sf.evaluate(a, b)
+    explicit = sf.evaluate(*awkward.broadcast_arrays(a, b))
+
+    assert_identical(direct, explicit)
+    assert awkward.to_list(direct) == awkward.to_list(2.0 * a + b)
+
+
+@pytest.mark.parametrize(
+    "make_pair",
+    [
+        pytest.param(
+            lambda: (
+                jagged(numpy.arange(9), [4, 0, 3, 2]),
+                jagged(numpy.arange(9), [3, 2, 2, 2]),
+            ),
+            id="same-depth-different-offsets",
+        ),
+        pytest.param(
+            lambda: (
+                awkward.Array(numpy.arange(9.0)),
+                awkward.Array(numpy.arange(8.0)),
+            ),
+            id="flat-different-lengths",
+        ),
+    ],
+)
+def test_unbroadcastable_still_raises(sf, make_pair):
+    a, b = make_pair()
+    with pytest.raises(ValueError):
+        sf.evaluate(a, b)
+
+
+def test_behavior_and_attrs_survive(sf):
+    a = awkward.Array(
+        jagged(numpy.arange(9), [4, 0, 3, 2]).layout,
+        behavior={"__test__": 1},
+        attrs={"key": "value"},
+    )
+    b = jagged(numpy.arange(100, 109), [4, 0, 3, 2])
+    out = sf.evaluate(a, b)
+
+    assert out.behavior == {"__test__": 1}
+    assert dict(out.attrs) == {"key": "value"}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Branch: [`lgray:perf/awkward-eval-fastpath`](https://github.com/lgray/correctionlib/tree/perf/awkward-eval-fastpath) (from `cms-nanoAOD/correctionlib@269ea97`)

Cut down after review: the structural fast path that used to be item 2 here is now scikit-hep/awkward#4326, inside `ak.transform`'s own option broadcasting, where it benefits every caller. This PR is only item 1.

## The problem

`Correction.evaluate` on awkward inputs goes through `highlevel._wrap_awkward`, which does

```python
array_args = awkward.broadcast_arrays(*array_args)
return awkward.transform(tocall, *array_args)
```

`ak.transform` broadcasts its inputs itself, so the explicit `broadcast_arrays` pass does that work twice. Profiling a real CMS b-tag shape correction (`deepJet_shape.evaluate(systematic, flavour, abseta, pt, discriminant)`) on one 100k-event partition, four option-jagged arguments (`100000 * var * ?int64` and three `100000 * var * ?float32`, 36,565 non-`None` entries):

| stage | min of 20 |
|---|---|
| `Correction.evaluate(...)` | 10.47 ms |
| `ak.broadcast_arrays(*4)` alone | 3.87 ms |
| `ak.transform(...)` on already-broadcast inputs | 6.49 ms |
| `Correction._base.evalv` on the flat leaf buffers | 2.54 ms |

## The change

Drop the `awkward.broadcast_arrays` call. Same real inputs, same process, min of 20: 10.39 ms before, 6.53 ms after, byte-identical output (values, `None` mask, type and layout form). With scikit-hep/awkward#4326 on top, the synthetic four-argument version of that call goes from 5.33 ms to 1.71 ms.

`dask_awkward` is untouched (`_wrap_dask_awkward` calls `_wrap_awkward` per partition and on the typetracer `meta`, both of which `ak.transform` broadcasts as before); `tests/test_highlevel.py::test_highlevel_dask` passes unchanged.

## Tests

`tests/test_highlevel_broadcast.py` pins the shapes the explicit pass used to handle to the answer an explicit `awkward.broadcast_arrays` gives: jagged against flat, a length-1 array against a longer one, and an option array against a plain one, each also checked against the closed form `2a + b`; unbroadcastable arguments (different offsets at equal depth, different flat lengths) still raise `ValueError`; `behavior` and `attrs` still come out of the result.

Suite: `tests/` excluding `test_cvmfs.py` (needs CVMFS) and `test_binding.py` (needs the installed `correction` CLI and a C++ toolchain) passes; `ruff check` and `ruff format --check` are clean on the two touched files.

## How this was built and checked

The C++ extension was not rebuilt: the released 2.9.0 wheel's `_core*.so` and `lib/` were copied next to the checkout's pure-Python sources and the checkout's `src/` put on `PYTHONPATH`. `src/correctionlib/highlevel.py` at `269ea97` is byte-identical to the 2.9.0 wheel's, and this change is pure Python, so the overlay exercises exactly the code in this diff.
